### PR TITLE
Fix roots and leafs of DAG

### DIFF
--- a/pkgs/lib/src/algorithm/dag.test.ts
+++ b/pkgs/lib/src/algorithm/dag.test.ts
@@ -106,8 +106,11 @@ describe("DAG.findPartialPath", () => {
       if (!node.includes("b")) {
         return;
       }
-      const { children } = dag.edges.get(nodeId);
-      for (const child of children) {
+      const edge = dag.edges.get(nodeId);
+      if (edge === undefined) {
+        throw new Error("children not found");
+      }
+      for (const child of edge.children) {
         const childNode = dag.nodes.get(child.to);
         if (childNode.includes("c")) {
           yield [nodeId, child.to];
@@ -243,5 +246,25 @@ describe("DAG.findWaypointPath cost", () => {
         path: [a, b],
       },
     ]);
+  });
+});
+
+describe("roots", () => {
+  it("should work", () => {
+    const nodes = new Nodes<string>();
+    nodes.add("a");
+    const dag1 = new DAG<string, number>(nodes);
+    // dag1は一つもedgeを持たないため、rootもない
+    expect(dag1.roots.length).toBe(0);
+  });
+});
+
+describe("leafs", () => {
+  it("should work", () => {
+    const nodes = new Nodes<string>();
+    nodes.add("a");
+    const dag1 = new DAG<string, number>(nodes);
+    // dag1は一つもedgeを持たないため、rootもない
+    expect(dag1.leafs.length).toBe(0);
   });
 });

--- a/pkgs/lib/src/algorithm/graph-string.ts
+++ b/pkgs/lib/src/algorithm/graph-string.ts
@@ -50,6 +50,10 @@ export class StringFinder<Node, EdgeValue> {
     dag: DAG<Node, EdgeValue>,
     query: string,
   ): Generator<DagStrRange, undefined> {
+    const edge = dag.edges.get(nodeID);
+    if (edge === undefined) {
+      throw new Error(`dag does not have the specified node: ${nodeID}`);
+    }
     const targetChars = this.charsMap.add(
       nodeID,
       this.mapper(dag.nodes.get(nodeID)!),
@@ -77,7 +81,7 @@ export class StringFinder<Node, EdgeValue> {
 
     // ここでは必ずStrRange:incompleteなので、remainQueryStartPosは必ず存在する
     const remainQuery = query.slice(StrPos.toNumber(remainQueryStartPos!));
-    const children = (dag.edges.get(nodeID) ?? []).children.map((c) => c.to);
+    const children = edge.children.map((c) => c.to);
     for (const child of children) {
       for (const result of this.startWithFromNode([child], dag, remainQuery)) {
         yield {
@@ -97,6 +101,10 @@ export class StringFinder<Node, EdgeValue> {
   ): Generator<DagStrPrefix> {
     // nodeIDのノードで完結するケース
     const nodeID = path[path.length - 1];
+    const edge = dag.edges.get(nodeID);
+    if (edge === undefined) {
+      throw new Error(`dag does not have the specified node: ${nodeID}`);
+    }
     const node = dag.nodes.get(nodeID)!;
     this.charsMap.add(nodeID, this.mapper(node));
     const nodeStr = this.charsMap.getStr(nodeID)!;
@@ -114,7 +122,7 @@ export class StringFinder<Node, EdgeValue> {
     }
 
     // nodeIDのノードで完結しないケース
-    const children = (dag.edges.get(nodeID) ?? []).children.map((c) => c.to);
+    const children = edge.children.map((c) => c.to);
     for (const child of children) {
       yield* this.startWithFromNode(
         [...path, child],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタ**
	- DAG内の特定のエッジケースをより良く扱うために、`DAG.findPartialPath`のロジックを改善しました。
- **新機能**
	- DAGクラスの`roots`と`leafs`プロパティのテストケースを追加しました。
- **改善点**
	- 指定されたノードがDAG内に見つからない場合の処理を改善しました。ノードが存在しない場合はエラーを投げるようにエラーハンドリングを強化しました。効率のために`edge`に直接アクセスします。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->