### PR TITLE
Allow duplicated label in dag

### DIFF
--- a/pkgs/lib/package.json
+++ b/pkgs/lib/package.json
@@ -7,7 +7,7 @@
     "format": "prettier --write .",
     "watch:type-check": "npx tsc --noEmit --watch",
     "test": "run-p test:*",
-    "test:unit": "vitest",
+    "test:unit": "vitest run",
     "test:lint": "eslint .",
     "test:format": "prettier --check .",
     "test:type-check": "tsc --noEmit"

--- a/pkgs/lib/src/algorithm/dag.test.ts
+++ b/pkgs/lib/src/algorithm/dag.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { DAG, FindPathOptions, Nodes, Path } from "./dag";
-import { DagForest, FindPartialPathOp } from "./dag-forest";
-import { NodeID } from "./values";
+import { DAG, type FindPathOptions, Nodes, type Path } from "./dag";
+import { DagForest, type FindPartialPathOp } from "./dag-forest";
+import type { NodeID } from "./values";
 
 describe("Nodes.getFromHex", () => {
   it("string", () => {
@@ -40,6 +40,29 @@ describe("Nodes.getId", () => {
     const nodes = new Nodes<{ a: number }>((n) => n.a.toString());
     const nodeId = nodes.add({ a: 1 });
     expect(nodes.getId({ a: 1 })).toEqual(nodeId);
+  });
+});
+
+describe("Nodes duplicate labels", () => {
+  it("allows multiple nodes with the same label and lists all IDs via getIdsByHex", () => {
+    const nodes = new Nodes<string>();
+    const id1 = nodes.add("a");
+    const id2 = nodes.add("a");
+    expect(id1).not.toEqual(id2);
+    expect(nodes.get(id1)).toEqual("a");
+    expect(nodes.get(id2)).toEqual("a");
+    const ids = nodes.getIdsByHex("a");
+    expect(ids.length).toBe(2);
+    expect(ids).toContain(id1);
+    expect(ids).toContain(id2);
+  });
+
+  it("getIdByHex/getByHex return the first inserted ID/value for backward compatibility", () => {
+    const nodes = new Nodes<string>();
+    const id1 = nodes.add("a");
+    nodes.add("a");
+    expect(nodes.getIdByHex("a")).toEqual(id1);
+    expect(nodes.getByHex("a")).toEqual("a");
   });
 });
 
@@ -351,7 +374,7 @@ describe("dfs", () => {
     dag1.edges.add(b, d, 0);
 
     const g = dag1.dfs();
-    let op: undefined | "skip" = undefined;
+    let op: undefined | "skip";
     const paths = [];
     for (let v = g.next(); !v.done; v = g.next(op)) {
       const path = v.value;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support multiple nodes sharing the same label; each insertion gets a new ID.
  * Added getIdsByHex(hex) to retrieve all IDs for a label.
  * Existing lookups still return the first inserted ID for backward compatibility.

* **Tests**
  * Expanded coverage for duplicate labels and pathfinding scenarios; minor DFS test tweak.

* **Chores**
  * Updated unit test script to use a single-run execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->